### PR TITLE
Get build passing on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,15 @@ notifications:
   recipients:
 otp_release:
   - 17.1
+jdk:
+  - oraclejdk7
 before_install:
+  # install Neo4j locally:
+  - wget dist.neo4j.org/neo4j-community-2.2.2-unix.tar.gz
+  - tar -xzf neo4j-community-2.2.2-unix.tar.gz
+  - sed -i.bak s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g neo4j-community-2.2.2/conf/neo4j-server.properties
+  - neo4j-community-2.2.2/bin/neo4j start
+  # install elixir
   - wget http://s3.hex.pm/builds/elixir/v1.0.0.zip
   - unzip -d elixir v1.0.0.zip
 before_script:

--- a/test/neoxir_test.exs
+++ b/test/neoxir_test.exs
@@ -74,11 +74,10 @@ defmodule NeoxirTest do
         [statement: "AAAAREATE (n) RETURN ID(n) as x2"]
       ]
 
-      {:error, _, response} = commit(session, statements)
-      assert response == [%{"code" => "Neo.ClientError.Statement.InvalidSyntax",
-     "message" => "Invalid input 'Q': expected <init> (line 1, column 1)\n\"QQCREATE (n) RETURN ID(n) as x1\"\n ^"}]
+      {:error, _, [response|_]} = commit(session, statements)
+      assert response["code"] == "Neo.ClientError.Statement.InvalidSyntax"
+      assert Regex.match?(~r/Invalid input/, response["message"])
     end
-
 
     # commit!
 

--- a/test/neoxir_test.exs
+++ b/test/neoxir_test.exs
@@ -28,20 +28,17 @@ defmodule NeoxirTest do
     # commit
 
     test "commit: single valid statement", %{session: session} do
-      {:ok, response} = commit(session, statement: "CREATE (n) RETURN ID(n) as x")
-      assert length(response) == 1
-      first_row = List.first(response)
-      assert Dict.keys(first_row) == [:x]
-      assert is_number(first_row[:x])
+      {:ok, [response]} = commit(session, statement: "CREATE (n) RETURN ID(n) as x")
+      assert Dict.keys(response) == [:x]
+      assert is_number(response[:x])
     end
+
 
     test "commit: with REST response", %{session: session}  do
-      {:ok, rows} = commit(session, statement: "CREATE (n {name: 'andreas'}) RETURN n", resultDataContents: [ "REST" ])
-      assert length(rows) == 1
-      assert rows |> List.first |> Dict.keys == [:n]
-      assert rows |> List.first |> Dict.get(:n) |> Dict.get("data") == %{"name" => "andreas"}
+      {:ok, [response]} = commit(session, statement: "CREATE (n {name: 'andreas'}) RETURN n", resultDataContents: [ "REST" ])
+      assert response |> Dict.keys == [:n]
+      assert response |> Dict.get(:n) |> Dict.get("data") == %{"name" => "andreas"}
     end
-
 
 
     test "commit: many valid statements", %{session: session} do
@@ -52,12 +49,10 @@ defmodule NeoxirTest do
 
       {:ok, response} = commit(session, statements)
 
-      [_, second_result ] = response
+      [_, [second_result]] = response
 
-      assert length(second_result) == 1
-      first_row = List.first(second_result)
-      assert Dict.keys(first_row) == [:x2]
-      assert is_number(first_row[:x2])
+      assert Dict.keys(second_result) == [:x2]
+      assert is_number(second_result[:x2])
     end
 
 
@@ -74,19 +69,17 @@ defmodule NeoxirTest do
         [statement: "AAAAREATE (n) RETURN ID(n) as x2"]
       ]
 
-      {:error, _, [response|_]} = commit(session, statements)
-      assert response["code"] == "Neo.ClientError.Statement.InvalidSyntax"
-      assert Regex.match?(~r/Invalid input/, response["message"])
+      {:error, _, [reason]} = commit(session, statements)
+      assert reason["code"] == "Neo.ClientError.Statement.InvalidSyntax"
+      assert Regex.match?(~r/Invalid input/, reason["message"])
     end
 
     # commit!
 
     test "commit!: single valid statement", %{session: session} do
-      response = commit!(session, statement: "CREATE (n) RETURN ID(n) as x")
-      assert length(response) == 1
-      first_row = List.first(response)
-      assert Dict.keys(first_row) == [:x]
-      assert is_number(first_row[:x])
+      [response] = commit!(session, statement: "CREATE (n) RETURN ID(n) as x")
+      assert Dict.keys(response) == [:x]
+      assert is_number(response[:x])
     end
 
 


### PR DESCRIPTION
Set up neo4j through the .travis.yml, following workaround described at
https://github.com/travis-ci/travis-ci/issues/3243.

One test was failing: "test commit: many invalid statements
(NeoxirTest.Commit)" because the response returned from neo4j has
changed slightly since the test was originally written. Relaxed the assertion
with a Regex.
