### PR TITLE
Update HTTPoison to 0.8.0 for use with OTP 18

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Neoxir.Mixfile do
      elixir: "~> 1.0",
      deps: deps, 
      package: package,
-     source_url: "https://github.com/ASCrookes/neoxir",
+     source_url: "https://github.com/andreasronge/neoxir",
      description: "An Elixir driver for the Neo4j Graph Database, see www.neo4j.org"]
   end
 
@@ -38,6 +38,6 @@ defmodule Neoxir.Mixfile do
 
   defp package do
     %{licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/ASCrookes/neoxir"}}
+      links: %{"Github" => "https://github.com/andreasronge/neoxir"}}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Neoxir.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [ 
-      { :httpoison, "~> 0.5"},
+      { :httpoison, "~> 0.8.0"},
       { :exjsx, "~> 3.1"},
       { :meck, "~> 0.8.2", only: :test },
       { :ex_doc, "~> 0.7", only: :docs }

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Neoxir.Mixfile do
      elixir: "~> 1.0",
      deps: deps, 
      package: package,
-     source_url: "https://github.com/andreasronge/neoxir",
+     source_url: "https://github.com/ASCrookes/neoxir",
      description: "An Elixir driver for the Neo4j Graph Database, see www.neo4j.org"]
   end
 
@@ -38,6 +38,6 @@ defmodule Neoxir.Mixfile do
 
   defp package do
     %{licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/andreasronge/neoxir"}}
+      links: %{"Github" => "https://github.com/ASCrookes/neoxir"}}
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,13 @@
-%{"ex_doc": {:hex, :ex_doc, "0.7.0"},
+%{"certifi": {:hex, :certifi, "0.3.0"},
+  "ex_doc": {:hex, :ex_doc, "0.7.0"},
   "exjsx": {:hex, :exjsx, "3.1.0"},
-  "hackney": {:hex, :hackney, "0.14.3"},
-  "httpoison": {:hex, :httpoison, "0.5.0"},
-  "idna": {:hex, :idna, "1.0.1"},
+  "hackney": {:hex, :hackney, "1.4.8"},
+  "httpoison": {:hex, :httpoison, "0.8.1"},
+  "idna": {:hex, :idna, "1.0.3"},
   "jsex": {:hex, :jsex, "2.0.0"},
   "json": {:hex, :json, "0.3.2"},
   "jsx": {:hex, :jsx, "2.4.0"},
   "meck": {:hex, :meck, "0.8.2"},
-  "shouldi": {:hex, :shouldi, "0.2.1"}}
+  "mimerl": {:hex, :mimerl, "1.0.2"},
+  "shouldi": {:hex, :shouldi, "0.2.1"},
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}


### PR DESCRIPTION
Was getting an error compiling because the version of hackney did
not support OTP 18. Its rebar.config max went to 17.

Running `mix deps.compile` gave the following error:

```
** (Mix) Could not compile dependency :hackney, "/Users/amadou/.mix/rebar" command failed. You can recompile this dependency with "mix deps.compile hackney", update it with "mix deps.update hackney" or clean it with "mix deps.clean hackney"
```
